### PR TITLE
Changed the title of the README file from Service Area Business Hero Package to App Init Package to better reflect the purpose of the package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Service Area Business Hero Package
+# App Init Package
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/fuelviews/app-init.svg?style=flat-square)](https://packagist.org/packages/fuelviews/app-init)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/fuelviews/app-init/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/fuelviews/app-init/actions?query=workflow%3Arun-tests+branch%3Amain)


### PR DESCRIPTION
Updates the title of the README file from "Service Area Business Hero Package" to "App Init Package." 

The motivation behind this change is to provide a clearer and more accurate description of the package's purpose. The new title better reflects the functionality and intent of the package, making it easier for users and contributors to understand its role within the project.

By improving the clarity of the documentation, we enhance the overall user experience and ensure that users can quickly grasp the package's purpose, ultimately leading to better adoption and usage.