### PR TITLE
Merge ours for package.json, package-lock.json, composer.json, and composer.lock in the stubs/.gitattributes.stub file.

### DIFF
--- a/stubs/.gitattributes.stub
+++ b/stubs/.gitattributes.stub
@@ -29,7 +29,3 @@ CHANGELOG.md        export-ignore
 # Merge ours
 *.css merge=ours
 *.js merge=ours
-package.json merge=ours
-package-lock.json merge=ours
-composer.json merge=ours
-composer.lock merge=ours


### PR DESCRIPTION
### Pull Request Description

This pull request implements a strategic merge configuration for specific files in the `stubs/.gitattributes.stub` file. By setting the merge strategy to "ours" for the `package.json`, `package-lock.json`, `composer.json`, and `composer.lock` files, we ensure that during merge conflicts, the versions from our current branch will be prioritized over those from other branches.

#### Motivation

The motivation behind this change is to maintain consistency and control over our dependency management files. In many cases, these files can be auto-generated or modified by package managers, leading to potential conflicts that may not be relevant to our project’s specific needs. By applying the "ours" merge strategy, we can avoid unnecessary manual conflict resolution and ensure that our branch retains its intended state for these critical files.

#### Improvement to the Project

1. **Reduced Merge Conflicts**: This change minimizes the likelihood of merge conflicts in commonly modified files, streamlining the development workflow.
  
2. **Consistency**: It ensures that our project consistently uses the dependency versions specified in our branch, preventing unintended changes from external branches.

3. **Efficiency**: Developers can focus on code changes rather than spending time resolving conflicts in dependency files, enhancing overall productivity.

By merging this pull request, we reinforce our workflow efficiency and maintain better control over our project's dependencies.