### PR TITLE
Change the .gitignore.stub file to include the /build directory and exclude the build directory, in order to properly ignore the build artifacts and improve the organization of the repository.

### DIFF
--- a/.github/workflows/open-ai-pr-description.yml
+++ b/.github/workflows/open-ai-pr-description.yml
@@ -15,7 +15,7 @@ jobs:
   openai-pr-description:
     runs-on: ubuntu-22.04
     # Run the job only if the actor is NOT Dependabot
-    if: ${{ !startsWith(github.actor, 'dependabot') }
+    if: ${{ !startsWith(github.actor, 'dependabot') }}
     steps:
       - uses: platisd/openai-pr-description@master
         with:

--- a/stubs/.gitignore.stub
+++ b/stubs/.gitignore.stub
@@ -1,6 +1,6 @@
 .idea
 .phpunit.cache
-build
+/build
 coverage
 docs
 phpunit.xml


### PR DESCRIPTION
Modifies the `.gitignore.stub` file to ensure that the `/build` directory is properly ignored. By including the `/build` directory in the `.gitignore`, we prevent build artifacts from cluttering the repository, leading to a cleaner and more organized project structure.

The change also corrects a minor formatting issue in the CI workflow file for consistency. 

Overall, these updates enhance the project's maintainability by ensuring that unnecessary files do not get tracked in version control, making it easier for developers to navigate the repository and focus on the essential parts of the codebase.