### PR TITLE
Enable dark mode support by adding the 'darkMode' configuration set to 'class' in the Tailwind CSS stub.

### DIFF
--- a/stubs/tailwind.config.js.stub
+++ b/stubs/tailwind.config.js.stub
@@ -8,6 +8,7 @@ export default {
         './resources/**/*.{js,vue,blade.php}',
         './vendor/fuelviews/laravel-*/resources/**/*.{js,vue,blade.php}',
     ],
+    darkMode: 'class',
     theme: {
         extend: {
             fontFamily: {


### PR DESCRIPTION
**Summary of Changes:**

1. **File Modified:** `stubs/tailwind.config.js.stub`
2. **Change Details:**
   - Added the `darkMode` configuration set to `'class'` within the Tailwind CSS configuration.
   - This change enables dark mode support by allowing developers to apply dark mode styles using a specific class, enhancing the project's flexibility in supporting different themes.